### PR TITLE
AT_003.09.03 | Footer > Download OpenWeather app module > Visibility, structure, links сlickability>Download on the App Store brand-link's clickabil

### DIFF
--- a/tests/test_group_ducktales.py
+++ b/tests/test_group_ducktales.py
@@ -114,3 +114,6 @@ def test_tc_003_09_03_app_store_brand_link_clickable(driver, open_and_load_main_
     actual_page_number = len(driver.window_handles)
     assert actual_page_number == initial_page_number + 1, \
         "The new web tab does not opened after click App Store brand-link's"
+
+
+

--- a/tests/test_group_ducktales.py
+++ b/tests/test_group_ducktales.py
@@ -106,3 +106,11 @@ def test_tc_003_09_02_app_store_brand_link_display(driver, open_and_load_main_pa
     assert app_store_brand_link.is_displayed(), "The brand-link for Download on the App Store is not displaying"
 
 
+def test_tc_003_09_03_app_store_brand_link_clickable(driver, open_and_load_main_page):
+    initial_page_number = len(driver.window_handles)
+    driver.find_element(*MODULE_DOWNLOAD_OPENWEATHER_APP).location_once_scrolled_into_view
+    app_store_brand_link = driver.find_element(*APP_STORE_BRAND_LINK)
+    app_store_brand_link.click()
+    actual_page_number = len(driver.window_handles)
+    assert actual_page_number == initial_page_number + 1, \
+        "The new web tab does not opened after click App Store brand-link's"


### PR DESCRIPTION
AT_003.09.03:https://trello.com/c/vppt2iVh/590-at0030903-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickabilitydownload-on-the-app-store-brand-links-cl
TC_003.09.03:https://trello.com/c/opJpPlx2/93-tc0030903-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickabilitydownload-on-the-app-store-brand-links-cl