### PR TITLE
AT_005.06.02 Weather API > Climatic forecast 30 days > Redirect to the How to make an API call section of the page

### DIFF
--- a/tests/test_group_pythonista.py
+++ b/tests/test_group_pythonista.py
@@ -5,6 +5,8 @@ URL_API = 'https://openweathermap.org/api'
 
 URL_FORCAST30 = 'https://openweathermap.org/api/forecast30'
 TITLE_FORCAST30 = (By.CSS_SELECTOR, '.col-sm-7 .breadcrumb-title')
+LINK_HOW_TO_MAKE = (By.CSS_SELECTOR, "a[href$='geo-year']")
+TITLE_HOW_TO_MAKE = (By.XPATH, '//*[@id="geo-year"]/h3')
 
 FOOTER_PANEL = (By.XPATH, '//*[@id="stick-footer-panel"]/div')
 BTN_ALLOW_ALL = (By.CLASS_NAME, "stick-footer-panel__link")
@@ -20,7 +22,6 @@ BTN_COOKIES = (By.CLASS_NAME, "stick-footer-panel__link")
 ALERT_PANEL_SINGIN = (By.CSS_SELECTOR, '.col-md-6 .panel-heading')
 HISTORICAL_WEATHER_DATA_COLLECTION_LINK = (By.XPATH, "//section[@id='pro']//p/a[contains(@href, '#history')]")
 WEATHER_MAPS_COLLECTION_LINK = (By.XPATH, "//section[@id='pro']//p/a[contains(@href, '#maps')]")
-
 
 
 def test_TC_003_11_01_verify_the_copyright_information_is_present_on_the_page(driver, open_and_load_main_page, wait):
@@ -53,7 +54,7 @@ def test_TC_002_03_06_dashboard_link_opens_correct_page(driver, open_and_load_ma
     assert driver.current_url == expected_url
 
 
-def test_TC_005_04_02_Professional_collection_section_is_presented(driver, wait):
+def test_TC_005_04_02_professional_collection_section_is_presented(driver, wait):
     driver.get(URL_API)
     wait.until(EC.presence_of_element_located(PROFESSIONAL_COLLESTION_TITLE))
     proffecional_collection_title = driver.find_element(*PROFESSIONAL_COLLESTION_TITLE)
@@ -105,3 +106,12 @@ def test_TC_005_06_1_visibility_climatic_forecast_30_days_page_title(driver):
     driver.get(URL_FORCAST30)
     title_page = driver.find_element(*TITLE_FORCAST30).text
     assert title_page == 'Climate forecast for 30 days', 'The title of the page does not match the expected value'
+
+
+def test_TC_005_06_02_redirect_to_the_how_to_make_an_API_call_section_of_the_page(driver):
+    driver.get(URL_FORCAST30)
+    driver.find_element(*LINK_HOW_TO_MAKE).click()
+    new_page_title = driver.find_element(*TITLE_HOW_TO_MAKE)
+    assert new_page_title.is_displayed(), 'The title of the page does not match the expected value'
+
+


### PR DESCRIPTION
TC_005.06.02 | Weather API > Climatic forecast 30 days > Redirect to the "How to make an API call" section of the page

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;dPC661gQ&#x2F;604-at0050602-weather-api-climatic-forecast-30-days-redirect-to-the-how-to-make-an-api-call-section-of-the-page">AT_005.06.02 | Weather API &gt; Climatic forecast 30 days &gt; Redirect to the &quot;How to make an API call&quot; section of the page</a></blockquote>