### PR TITLE
AT_003.09.05 | Footer > Download OpenWeather app module > Visibility, structure, links сlickability>GET IT ON Google Play brand-link is displayed

### DIFF
--- a/tests/test_group_ducktales.py
+++ b/tests/test_group_ducktales.py
@@ -159,5 +159,14 @@ def test_tc_003_09_04_google_play_brand_link_clickable(driver, open_and_load_mai
     assert actual_page_number == initial_page_number + 1, \
         "The new web tab does not opened after click Google Play brand-link's"
 
+
+def test_tc_003_09_04_google_play_brand_link_display(driver, open_and_load_main_page):
+    driver.find_element(*MODULE_DOWNLOAD_OPENWEATHER_APP).location_once_scrolled_into_view
+    google_play_brand_link = driver.find_element(*GOOGLE_PLAY_BRAND_LINK)
+    assert google_play_brand_link.is_displayed(), "Google Play brand-link is not displaying"
+
+
+
+
                                                                                                       
                                                                                                       


### PR DESCRIPTION
AT_003.09.05:https://trello.com/c/FM1Z5Keb/595-at0030905-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickabilityget-it-on-google-play-brand-link-is-disp
TC_003.09.05:https://trello.com/c/nRHEewzz/334-tc0030905-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickabilityget-it-on-google-play-brand-link-is-disp