### PR TITLE
AT_001.04.06 | Main page >8-day-forecast >  days of the week

### DIFF
--- a/tests/test_group_ducktales.py
+++ b/tests/test_group_ducktales.py
@@ -19,8 +19,10 @@ SEARCH_DROPDOWN_MENU_FIRST_CHILD = By.CSS_SELECTOR, 'ul.search-dropdown-menu li:
 SEARCH_DROPDOWN_MENU_FIRST_CHILD_TEXT = By.CSS_SELECTOR, '.grid-container.grid-4-5 h2'
 MODULE_DOWNLOAD_OPENWEATHER_APP = By.XPATH, "//div[@class='my-5']/p"
 FIRST_DAY_IN_8_DAY_FORECAST = By.CSS_SELECTOR, 'ul.day-list li:nth-child(1) span:nth-child(1)'
+LIST_DAYS_IN_8_DAY_FORECAST = By.CSS_SELECTOR, 'div .day-list'
+DAYS_IN_8_DAY_FORECAST = By.CSS_SELECTOR, 'div .day-list li'
 
-WEEKDAYS = ('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun')
+WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 MONTHS = ('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November',
           'December')
 APP_STORE_BRAND_LINK = By.CSS_SELECTOR, "img[src='/themes/openweathermap/assets/img/mobile_app/app-store-badge.svg']"
@@ -201,4 +203,13 @@ def test_tc_017_04_01_module_create_api_key_is_visible(driver, open_api_keys_pag
     assert module_create_api_key.is_displayed(), "module with title “Create key“ does not visible"
 
 
+def test_TC_001_04_06_verify_in_day_list_days_of_the_week(driver, open_and_load_main_page):
+    driver.find_element(*LIST_DAYS_IN_8_DAY_FORECAST).location_once_scrolled_into_view
+    days_by_page = []
+    days = driver.find_elements(*DAYS_IN_8_DAY_FORECAST)
+    for day in days:
+        days_by_page.append(day.text[:3])
+    number_day = datetime.now().weekday()
+    days_by_computer = WEEKDAYS[number_day:] + WEEKDAYS[:number_day] + WEEKDAYS[(number_day):(number_day + 1):]
+    assert days_by_page == days_by_computer
 


### PR DESCRIPTION
AT_001.04.06 | Main page > Search city widget > 8-day-forecast > Verify in day-list elements > days of the week

AT https://trello.com/c/J0xrYtgx/683-at0010406-main-page-search-city-widget-8-day-forecast-verify-in-day-list-elements-days-of-the-week

TC https://trello.com/c/tTfOnqBc/265-tc0010406-main-page-search-city-widget-8-day-forecast-verify-in-day-list-elements-days-of-the-week