### PR TITLE
AT_017.03.11 | API Keys tab> Rename API key> Visibility, clickability, rename API keys>Verify the API key name does not change if the input consists of spaces

### DIFF
--- a/tests/test_group_ducktales.py
+++ b/tests/test_group_ducktales.py
@@ -253,5 +253,3 @@ def test_tc_017_03_11_verify_the_api_key_name_does_not_change_if_the_input_consi
     api_key_name_before = get_api_key_name_before(driver, open_api_keys_page)
     api_key_name_after = driver.find_element(*API_KEY_NAME_SELECTOR).text
     assert api_key_name_after == api_key_name_before
-    print(api_key_name_after)
-    print(api_key_name_before)

--- a/tests/test_group_ducktales.py
+++ b/tests/test_group_ducktales.py
@@ -58,9 +58,7 @@ def open_api_keys_page(driver, open_and_load_main_page, sign_in, wait):
 def api_key_delete_name(driver, open_api_keys_page, wait):
     wait.until(EC.element_to_be_clickable(API_KEY_EDIT_SELECTOR)).click()
     api_key_enter = wait.until(EC.element_to_be_clickable(API_KEY_ENTER_SELECTOR))
-    api_key_enter.click()
-    api_key_enter.send_keys(Keys.CONTROL, 'a')
-    api_key_enter.send_keys(Keys.BACKSPACE)
+    api_key_enter.clear()
     return api_key_enter
 
 def get_api_key_name_before(driver, open_api_keys_page):

--- a/tests/test_group_ducktales.py
+++ b/tests/test_group_ducktales.py
@@ -26,6 +26,9 @@ DAYS_IN_8_DAY_FORECAST = By.CSS_SELECTOR, 'div .day-list li'
 WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 MONTHS = ('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November',
           'December')
+
+SPACEKITS = [' ', '          ', '                    ']
+
 APP_STORE_BRAND_LINK = By.CSS_SELECTOR, "img[src='/themes/openweathermap/assets/img/mobile_app/app-store-badge.svg']"
 
 COOKIES_LINK_SELECTOR = By.XPATH, "//button[@type='button']"
@@ -45,10 +48,24 @@ TAB_API_KEYS = By.CSS_SELECTOR, '#myTab [href="/api_keys"]'
 MODULE_API_KEY_CREATE = By.CSS_SELECTOR, '.col-md-4 h4'
 
 
+
 @pytest.fixture()
 def open_api_keys_page(driver, open_and_load_main_page, sign_in, wait):
     api_key_tab = driver.find_element(*TAB_API_KEYS)
     api_key_tab.click()
+
+@pytest.fixture()
+def api_key_delete_name(driver, open_api_keys_page, wait):
+    wait.until(EC.element_to_be_clickable(API_KEY_EDIT_SELECTOR)).click()
+    api_key_enter = wait.until(EC.element_to_be_clickable(API_KEY_ENTER_SELECTOR))
+    api_key_enter.click()
+    api_key_enter.send_keys(Keys.CONTROL, 'a')
+    api_key_enter.send_keys(Keys.BACKSPACE)
+    return api_key_enter
+
+def get_api_key_name_before(driver, open_api_keys_page):
+    return driver.find_element(*API_KEY_NAME_SELECTOR).text
+
 
 
 def test_tc_001_01_01_verify_city_name_displayed_by_zip(driver, open_and_load_main_page, wait):
@@ -228,3 +245,13 @@ def test_010_02_08_accessibility_of_question_headings(driver, open_and_load_main
     for heading in question_headings:
         assert heading.is_displayed(), "Error: FAQ header not displayed"
 
+
+@pytest.mark.parametrize('spacekit', SPACEKITS)
+def test_tc_017_03_11_verify_the_api_key_name_does_not_change_if_the_input_consists_of_spaces(driver, spacekit, api_key_delete_name, wait):
+    api_key_delete_name.send_keys(spacekit)
+    driver.find_element(*SAVE_BUTTON_SELECTOR).click()
+    api_key_name_before = get_api_key_name_before(driver, open_api_keys_page)
+    api_key_name_after = driver.find_element(*API_KEY_NAME_SELECTOR).text
+    assert api_key_name_after == api_key_name_before
+    print(api_key_name_after)
+    print(api_key_name_before)


### PR DESCRIPTION
https://trello.com/c/7Ia7kFmE/761-at0170311-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysverify-the-api-key-name-does-not-change-if-the-inpu