### PR TITLE
RF_AT_003.09.02| Footer > Download OpenWeather app module > Visibility, structure, links сlickability> Download on the App Store brand-link display

### DIFF
--- a/tests/test_group_ducktales/locators/main_locators.py
+++ b/tests/test_group_ducktales/locators/main_locators.py
@@ -20,5 +20,6 @@ class MainLocator:
     FIRST_DAY_IN_8_DAY_FORECAST = By.CSS_SELECTOR, 'ul.day-list li:nth-child(1) span:nth-child(1)'
     LIST_DAYS_IN_8_DAY_FORECAST = By.CSS_SELECTOR, 'div .day-list'
     DAYS_IN_8_DAY_FORECAST = By.CSS_SELECTOR, 'div .day-list li'
+    APP_STORE_BRAND_LINK = By.CSS_SELECTOR, "img[src='/themes/openweathermap/assets/img/mobile_app/app-store-badge.svg']"
 
 

--- a/tests/test_group_ducktales/pages/main_page.py
+++ b/tests/test_group_ducktales/pages/main_page.py
@@ -15,9 +15,19 @@ class MainPage(BasePage):
         today = WEEKDAYS[day_by_computer]
         return today
 
-    def check_module_title_download_openweather_app(self):
+    def go_to_module_download_openweather_app(self):
         module_download_openweather_app = self.driver.find_element(*MainLocator.MODULE_DOWNLOAD_OPENWEATHER_APP)
         self.go_to_element(module_download_openweather_app)
+        return module_download_openweather_app
+
+    def check_module_title_download_openweather_app(self):
+        module_download_openweather_app = self.go_to_module_download_openweather_app()
         assert module_download_openweather_app.is_displayed(), "Module title Download openweather app is not display"
+
+    def check_app_store_brand_link_display(self):
+        self.go_to_module_download_openweather_app()
+        # driver.find_element(*MODULE_DOWNLOAD_OPENWEATHER_APP).location_once_scrolled_into_view
+        app_store_brand_link = self.driver.find_element(*MainLocator.APP_STORE_BRAND_LINK)
+        assert app_store_brand_link.is_displayed(), "The brand-link for Download on the App Store is not displaying"
 
 

--- a/tests/test_group_ducktales/pages/main_page.py
+++ b/tests/test_group_ducktales/pages/main_page.py
@@ -26,7 +26,6 @@ class MainPage(BasePage):
 
     def check_app_store_brand_link_display(self):
         self.go_to_module_download_openweather_app()
-        # driver.find_element(*MODULE_DOWNLOAD_OPENWEATHER_APP).location_once_scrolled_into_view
         app_store_brand_link = self.driver.find_element(*MainLocator.APP_STORE_BRAND_LINK)
         assert app_store_brand_link.is_displayed(), "The brand-link for Download on the App Store is not displaying"
 

--- a/tests/test_group_ducktales/tests/test_main_page.py
+++ b/tests/test_group_ducktales/tests/test_main_page.py
@@ -15,6 +15,12 @@ class TestMainPage:
         page.open_page()
         page.check_module_title_download_openweather_app()
 
+    def test_tc_003_09_02_app_store_brand_link_display(self, driver):
+        page = MainPage(driver, LINK_MAIN_PAGE)
+        page.open_page()
+        page.check_app_store_brand_link_display()
+
+
 
 
 


### PR DESCRIPTION
RF_AT_003.09.02 : https://trello.com/c/HF95WcX1/838-rfat0030902-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickability-download-on-the-app-store-brand-link