### PR TITLE
RF_AT_001.02.04_01 | Main page > Search city widget > Verify the buttons for metric and imperial are visible and clickable

### DIFF
--- a/tests/test_group_ducktales/pages/main_page.py
+++ b/tests/test_group_ducktales/pages/main_page.py
@@ -32,4 +32,5 @@ class MainPage(BasePage):
     def check_buttons_displayed_and_enabled(self):
         imperial_button = self.driver.find_element(*MainLocator.TO_IMPERIAL_BTN)
         metric_button = self.driver.find_element(*MainLocator.TO_METRIC_BTN)
-        return all(button.is_displayed() and button.is_enabled() for button in [metric_button, imperial_button])
+        assert all(button.is_displayed() and button.is_enabled() for button in [metric_button, imperial_button]),\
+            "Toggle buttons are not displayed or enabled"

--- a/tests/test_group_ducktales/pages/main_page.py
+++ b/tests/test_group_ducktales/pages/main_page.py
@@ -29,4 +29,7 @@ class MainPage(BasePage):
         app_store_brand_link = self.driver.find_element(*MainLocator.APP_STORE_BRAND_LINK)
         assert app_store_brand_link.is_displayed(), "The brand-link for Download on the App Store is not displaying"
 
-
+    def check_buttons_displayed_and_enabled(self):
+        imperial_button = self.driver.find_element(*MainLocator.TO_IMPERIAL_BTN)
+        metric_button = self.driver.find_element(*MainLocator.TO_METRIC_BTN)
+        return all(button.is_displayed() and button.is_enabled() for button in [metric_button, imperial_button])

--- a/tests/test_group_ducktales/tests/test_main_page.py
+++ b/tests/test_group_ducktales/tests/test_main_page.py
@@ -20,7 +20,9 @@ class TestMainPage:
         page.open_page()
         page.check_app_store_brand_link_display()
 
-
-
+    def test_tc_001_02_04_01_switch_toggle_buttons(self, driver):
+        page = MainPage(driver, LINK_MAIN_PAGE)
+        page.open_page()
+        assert page.check_buttons_displayed_and_enabled()
 
 

--- a/tests/test_group_ducktales/tests/test_main_page.py
+++ b/tests/test_group_ducktales/tests/test_main_page.py
@@ -23,6 +23,5 @@ class TestMainPage:
     def test_tc_001_02_04_01_switch_toggle_buttons(self, driver):
         page = MainPage(driver, LINK_MAIN_PAGE)
         page.open_page()
-        assert page.check_buttons_displayed_and_enabled()
-
+        page.check_buttons_displayed_and_enabled()
 


### PR DESCRIPTION
RF_AT_001.02.04_01 [https://trello.com/c/uMQorvFS/756-rfat001020401-main-page-search-city-widget-verify-the-buttons-for-metric-and-imperial-are-visible-and-clickable](url)