### PR TITLE
RF_AT_005.08.04 | Road Risk API>Redirection to the How to request Road Risk API section of the page

### DIFF
--- a/tests/test_group_100000/locators/api_page_locators.py
+++ b/tests/test_group_100000/locators/api_page_locators.py
@@ -1,0 +1,7 @@
+from selenium.webdriver.common.by import By
+
+
+class RoadRiskApi:
+    ROAD_RISK_API_LINK = 'https://openweathermap.org/api/road-risk'
+    TITLE_HOW_TO_RR_API = (By.XPATH, "//*[@id='how']/h2")
+    LINK_HOW_TO_REQUEST_RR_API = (By.CSS_SELECTOR, 'a[href="#how"]')

--- a/tests/test_group_100000/pages/api_page.py
+++ b/tests/test_group_100000/pages/api_page.py
@@ -1,0 +1,11 @@
+from pages.base_page import BasePage
+from tests.test_group_100000.locators.api_page_locators import RoadRiskApi as R
+
+
+class RoadRiskApi(BasePage):
+    def check_redirect_to_page_section(self):
+        self.driver.find_element(*R.LINK_HOW_TO_REQUEST_RR_API).click()
+        section_title = self.driver.find_element(*R.TITLE_HOW_TO_RR_API)
+        assert section_title.is_displayed(), 'Title Not Found'
+
+

--- a/tests/test_group_100000/tests/test_road_risk_api.py
+++ b/tests/test_group_100000/tests/test_road_risk_api.py
@@ -1,0 +1,9 @@
+from tests.test_group_100000.pages.api_page import RoadRiskApi
+from tests.test_group_100000.locators.api_page_locators import RoadRiskApi as R
+
+
+def test_TC_005_08_04_redirection_to_the_how_to_request_road_risk_API_section_of_the_page(driver):
+    page = RoadRiskApi(driver, link=R.ROAD_RISK_API_LINK)
+    page.open_page()
+    page.check_redirect_to_page_section()
+


### PR DESCRIPTION
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;pqEmLcCv&#x2F;841-rfat0050804-road-risk-api-redirection-to-the-how-to-request-road-risk-api-section-of-the-page">RF_AT_005.08.04 | Road Risk API &gt; Redirection to the &quot;How to request Road Risk API&quot; section of the page</a></blockquote>

RF_AT_005.08.04 | Road Risk API > Redirection to the "How to request Road Risk API" section of the page