### PR TITLE
RF_AT_003.09.03 | Footer > Download OpenWeather app module > Visibility, structure, links сlickability>Download on the App Store brand-link's clickable.

### DIFF
--- a/tests/test_group_ducktales/pages/main_page.py
+++ b/tests/test_group_ducktales/pages/main_page.py
@@ -34,3 +34,12 @@ class MainPage(BasePage):
         metric_button = self.driver.find_element(*MainLocator.TO_METRIC_BTN)
         assert all(button.is_displayed() and button.is_enabled() for button in [metric_button, imperial_button]),\
             "Toggle buttons are not displayed or enabled"
+
+    def check_app_store_brand_link_clickable(self):
+        initial_page_number = len(self.driver.window_handles)
+        self.go_to_module_download_openweather_app()
+        app_store_brand_link = self.driver.find_element(*MainLocator.APP_STORE_BRAND_LINK)
+        app_store_brand_link.click()
+        actual_page_number = len(self.driver.window_handles)
+        assert actual_page_number == initial_page_number + 1, \
+            "The new web tab does not opened after click App Store brand-link's"

--- a/tests/test_group_ducktales/tests/test_main_page.py
+++ b/tests/test_group_ducktales/tests/test_main_page.py
@@ -25,3 +25,9 @@ class TestMainPage:
         page.open_page()
         page.check_buttons_displayed_and_enabled()
 
+    def test_tc_003_09_03_app_store_brand_link_clickable(self, driver):
+        page = MainPage(driver, LINK_MAIN_PAGE)
+        page.open_page()
+        page.check_app_store_brand_link_clickable()
+
+


### PR DESCRIPTION
RF_AT_003.09.03 : https://trello.com/c/QX0tL1Wz/850-rfat0030903-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickabilitydownload-on-the-app-store-brand-links