### PR TITLE
RF_AT_003.09.05 | Footer > Download OpenWeather app module > Visibility, structure, links сlickability>GET IT ON Google Play brand-link is displayed.

### DIFF
--- a/tests/test_group_ducktales/pages/main_page.py
+++ b/tests/test_group_ducktales/pages/main_page.py
@@ -32,7 +32,7 @@ class MainPage(BasePage):
     def check_buttons_displayed_and_enabled(self):
         imperial_button = self.driver.find_element(*MainLocator.TO_IMPERIAL_BTN)
         metric_button = self.driver.find_element(*MainLocator.TO_METRIC_BTN)
-        assert all(button.is_displayed() and button.is_enabled() for button in [metric_button, imperial_button]),\
+        assert all(button.is_displayed() and button.is_enabled() for button in [metric_button, imperial_button]), \
             "Toggle buttons are not displayed or enabled"
 
     def check_app_store_brand_link_clickable(self):
@@ -53,4 +53,7 @@ class MainPage(BasePage):
         assert actual_page_number == initial_page_number + 1, \
             "The new web tab does not opened after click Google Play brand-link's"
 
-
+    def check_google_play_brand_link_display(self):
+        self.go_to_module_download_openweather_app()
+        google_play_brand_link = self.driver.find_element(*MainLocator.GOOGLE_PLAY_BRAND_LINK)
+        assert google_play_brand_link.is_displayed(), "Google Play brand-link is not displaying"

--- a/tests/test_group_ducktales/tests/test_main_page.py
+++ b/tests/test_group_ducktales/tests/test_main_page.py
@@ -35,6 +35,11 @@ class TestMainPage:
         page.open_page()
         page.check_google_play_brand_link_clickable()
 
+    def test_tc_003_09_04_google_play_brand_link_display(self, driver):
+        page = MainPage(driver, LINK_MAIN_PAGE)
+        page.open_page()
+        page.check_google_play_brand_link_display()
+
 
 
 


### PR DESCRIPTION
RF_AT_003.09.05: https://trello.com/c/oylBOTGz/853-rfat0030905-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickabilityget-it-on-google-play-brand-link-is-di