### PR TITLE
AT_017.04.02| API Keys tab>Creating API Key >Visibility, clickability, creating>Verify that the API key name is limited to 20 characters.

### DIFF
--- a/tests/test_group_ducktales/locators/API_keys_locators.py
+++ b/tests/test_group_ducktales/locators/API_keys_locators.py
@@ -9,6 +9,10 @@ class ApiKeysLocator:
     SAVE_BUTTON_SELECTOR = By.CSS_SELECTOR, "button[class='button-round dark']"
     TAB_API_KEYS = By.CSS_SELECTOR, '#myTab [href="/api_keys"]'
     MODULE_API_KEY_CREATE = By.CSS_SELECTOR, '.col-md-4 h4'
+    EDIT_API_KEY_ICON = By.CSS_SELECTOR, '.edit_key_btn .fa-edit'
+    API_KEY_FIELD = (By.CSS_SELECTOR, '#new_edit_key_form .owm_input')
+    SAVE_NEW_API_NAME_BUTTON = By.CSS_SELECTOR, '.pop-up-footer .button-round.dark'
+    API_KEY_NAME_FIRST_ROW = By.XPATH, "//div[@class='col-md-8']//tr[1]//td[2]"
 
 
 

--- a/tests/test_group_ducktales/pages/API_keys_page.py
+++ b/tests/test_group_ducktales/pages/API_keys_page.py
@@ -1,3 +1,5 @@
+import time
+
 from pages.base_page import BasePage
 from ..locators.API_keys_locators import ApiKeysLocator
 
@@ -12,3 +14,26 @@ class ApiKeysPage(BasePage):
     def check_module_create_api_key_is_visible(self):
         module_create_api_key = self.driver.find_element(*ApiKeysLocator.MODULE_API_KEY_CREATE)
         assert module_create_api_key.is_displayed(), "module with title “Create key“ does not visible"
+
+    def open_popup_rename_api_key(self):
+        edit_api_key_icon = self.driver.find_element(*ApiKeysLocator.EDIT_API_KEY_ICON)
+        edit_api_key_icon.click()
+        self.driver.switch_to.default_content()
+
+    def enter_new_api_name(self, new_api_name):
+        api_key_field = self.element_is_clickable(ApiKeysLocator.API_KEY_FIELD, 10)
+        api_key_field.click()
+        api_key_field.clear()
+        api_key_field.send_keys(new_api_name)
+
+    def click_save_new_api_key_name_button(self):
+        save_api_key_name_button = self.driver.find_element(*ApiKeysLocator.SAVE_NEW_API_NAME_BUTTON)
+        save_api_key_name_button.click()
+
+    def api_key_name_of_first_row(self):
+        return self.driver.find_element(*ApiKeysLocator.API_KEY_NAME_FIRST_ROW).text
+
+    def check_limit_of_api_key_name(self):
+        api_name_limit = 20
+        actual_length_of_api_key_name = len(self.api_key_name_of_first_row())
+        assert actual_length_of_api_key_name == api_name_limit

--- a/tests/test_group_ducktales/pages/API_keys_page.py
+++ b/tests/test_group_ducktales/pages/API_keys_page.py
@@ -1,5 +1,3 @@
-import time
-
 from pages.base_page import BasePage
 from ..locators.API_keys_locators import ApiKeysLocator
 
@@ -36,4 +34,6 @@ class ApiKeysPage(BasePage):
     def check_limit_of_api_key_name(self):
         api_name_limit = 20
         actual_length_of_api_key_name = len(self.api_key_name_of_first_row())
-        assert actual_length_of_api_key_name == api_name_limit
+        assert actual_length_of_api_key_name == api_name_limit, "The limit of API key name does not correspond to " \
+                                                                "expected limit"
+

--- a/tests/test_group_ducktales/tests/test_API_keys_page.py
+++ b/tests/test_group_ducktales/tests/test_API_keys_page.py
@@ -1,4 +1,3 @@
-import time
 
 from tests.test_group_ducktales.pages.sign_in_page import SignInPage
 from tests.test_group_ducktales.test_data.sign_in_page_data import *

--- a/tests/test_group_ducktales/tests/test_API_keys_page.py
+++ b/tests/test_group_ducktales/tests/test_API_keys_page.py
@@ -1,3 +1,4 @@
+import time
 
 from tests.test_group_ducktales.pages.sign_in_page import SignInPage
 from tests.test_group_ducktales.test_data.sign_in_page_data import *
@@ -13,4 +14,18 @@ class TestApiKey:
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()
         api_keys_page.check_module_create_api_key_is_visible()
+
+    def test_tc_017_04_02_api_key_name_has_limit_20_characters(self, driver):
+        sign_in_page = SignInPage(driver, LINK_SIGN_IN_PAGE)
+        sign_in_page.open_page()
+        sign_in_page.log_in()
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.open_popup_rename_api_key()
+        api_keys_page.enter_new_api_name("New API name for test")
+        api_keys_page.click_save_new_api_key_name_button()
+        api_keys_page.check_limit_of_api_key_name()
+
+
+
 


### PR DESCRIPTION
AT_017.04.02 : https://trello.com/c/n0PooMPb/934-at0170402-api-keys-tabcreating-api-key-visibility-clickability-creatingverify-that-the-api-key-name-is-limited-to-20-characters
TC_017.04.02 : https://trello.com/c/I8xmQXcb/504-tc0170402-api-keys-tabcreating-api-key-visibility-clickability-creatingverify-that-the-api-key-name-is-limited-to-20-characters