### PR TITLE
RF_AT_017.04.02| API Keys tab>Creating API Key >Visibility, clickability, creating>Verify that the API key name is limited to 20 characters.

### DIFF
--- a/tests/test_group_ducktales/locators/API_keys_locators.py
+++ b/tests/test_group_ducktales/locators/API_keys_locators.py
@@ -13,6 +13,7 @@ class ApiKeysLocator:
     API_KEY_FIELD = (By.CSS_SELECTOR, '#new_edit_key_form .owm_input')
     SAVE_NEW_API_NAME_BUTTON = By.CSS_SELECTOR, '.pop-up-footer .button-round.dark'
     API_KEY_NAME_FIRST_ROW = By.XPATH, "//div[@class='col-md-8']//tr[1]//td[2]"
+    NEW_API_KEY_NAME = By.CSS_SELECTOR, ".new_api_key_form .owm_input"
 
 
 

--- a/tests/test_group_ducktales/pages/API_keys_page.py
+++ b/tests/test_group_ducktales/pages/API_keys_page.py
@@ -37,3 +37,13 @@ class ApiKeysPage(BasePage):
         assert actual_length_of_api_key_name == api_name_limit, "The limit of API key name does not correspond to " \
                                                                 "expected limit"
 
+    def enter_created_api_key_name(self, new_api_name):
+        new_api_key_name_field = self.driver.find_element(*ApiKeysLocator.NEW_API_KEY_NAME)
+        new_api_key_name_field.send_keys(new_api_name)
+
+    def check_limit_of_created_api_key_name(self):
+        expected_api_name_limit = 20
+        created_api_key_name = self.driver.find_element(*ApiKeysLocator.NEW_API_KEY_NAME)
+        actual_api_name_limit = int(created_api_key_name.get_attribute('maxlength'))
+        assert actual_api_name_limit == expected_api_name_limit, "The limit of created API key name does not correspond to " \
+                                                                "requirements"

--- a/tests/test_group_ducktales/tests/test_API_keys_page.py
+++ b/tests/test_group_ducktales/tests/test_API_keys_page.py
@@ -20,10 +20,11 @@ class TestApiKey:
         sign_in_page.log_in()
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()
-        api_keys_page.open_popup_rename_api_key()
-        api_keys_page.enter_new_api_name("New API name for test")
-        api_keys_page.click_save_new_api_key_name_button()
-        api_keys_page.check_limit_of_api_key_name()
+        api_keys_page.check_limit_of_created_api_key_name()
+
+
+
+
 
 
 


### PR DESCRIPTION
RF_AT_017.04.02: https://trello.com/c/AsnV2H02/978-rfat0170402-api-keys-tabcreating-api-key-visibility-clickability-creatingverify-that-the-api-key-name-is-limited-to-20-character