### PR TITLE
AT_017.04.03| API Keys tab>Creating API Key >Visibility, clickability, creating>Verify that the API key name field is required.

### DIFF
--- a/tests/test_group_ducktales/pages/API_keys_page.py
+++ b/tests/test_group_ducktales/pages/API_keys_page.py
@@ -46,4 +46,9 @@ class ApiKeysPage(BasePage):
         created_api_key_name = self.driver.find_element(*ApiKeysLocator.NEW_API_KEY_NAME)
         actual_api_name_limit = int(created_api_key_name.get_attribute('maxlength'))
         assert actual_api_name_limit == expected_api_name_limit, "The limit of created API key name does not correspond to " \
-                                                                "requirements"
+                                                                 "requirements"
+
+    def check_create_api_key_field_is_required(self):
+        new_api_key_name_field = self.driver.find_element(*ApiKeysLocator.NEW_API_KEY_NAME)
+        is_required = new_api_key_name_field.get_attribute('required')
+        assert is_required, "The field hasn't required attribute"

--- a/tests/test_group_ducktales/tests/test_API_keys_page.py
+++ b/tests/test_group_ducktales/tests/test_API_keys_page.py
@@ -1,4 +1,3 @@
-
 from tests.test_group_ducktales.pages.sign_in_page import SignInPage
 from tests.test_group_ducktales.test_data.sign_in_page_data import *
 from tests.test_group_ducktales.pages.API_keys_page import ApiKeysPage
@@ -22,10 +21,10 @@ class TestApiKey:
         api_keys_page.open_api_keys_page()
         api_keys_page.check_limit_of_created_api_key_name()
 
-
-
-
-
-
-
-
+    def test_tc_017_04_03_api_key_name_is_required(self, driver):
+        sign_in_page = SignInPage(driver, LINK_SIGN_IN_PAGE)
+        sign_in_page.open_page()
+        sign_in_page.log_in()
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.check_create_api_key_field_is_required()


### PR DESCRIPTION
AT_017.04.03 : https://trello.com/c/suSZg9i6/974-at0170403-api-keys-tabcreating-api-key-visibility-clickability-creatingverify-that-the-api-key-name-field-is-required
TC_017.04.03: https://trello.com/c/m3ZZFDZK/506-tc0170403-api-keys-tabcreating-api-key-visibility-clickability-creatingverify-that-the-api-key-name-field-is-required