### PR TITLE
AT_005.08.05 | Road Risk API >Redirection to the List of National Sources of Weather Warnings section of the page

### DIFF
--- a/tests/test_group_100000/locators/api_page_locators.py
+++ b/tests/test_group_100000/locators/api_page_locators.py
@@ -7,6 +7,9 @@ class RoadRiskApi:
     LINK_HOW_TO_REQUEST_RR_API = (By.CSS_SELECTOR, 'a[href="#how"]')
     SECTION_R_CONCEPTS = (By.XPATH, "//*[@id='concept']")
     TITLE_ROAD_RISK = (By.CSS_SELECTOR, '.breadcrumb-title')
+    LINK_LIST_OF_NATIONAL = (By.CSS_SELECTOR, "a[href$='listsource']")
+    TITLE_LIST_OF_NATIONAL = (By.XPATH, "//*[@id='listsource']/h3")
+
 
 class WeatherConditions:
     DRIZZLE_LOCATOR = (By.XPATH, '//a[contains(@href, "#Drizzle")]/ancestor-or-self::table')

--- a/tests/test_group_100000/pages/api_page.py
+++ b/tests/test_group_100000/pages/api_page.py
@@ -2,20 +2,35 @@ from pages.base_page import BasePage
 from tests.test_group_100000.locators.api_page_locators import RoadRiskApi as R
 from tests.test_group_100000.locators.api_page_locators import WeatherConditions as W
 
+
 class RoadRiskApi(BasePage):
+    page_loc = R
+
+    def open_road_risk_api_page(self):
+        self.driver.get(R.ROAD_RISK_API_LINK)
+
     def check_redirect_to_page_section(self):
+        self.open_road_risk_api_page()
         self.driver.find_element(*R.LINK_HOW_TO_REQUEST_RR_API).click()
         section_title = self.driver.find_element(*R.TITLE_HOW_TO_RR_API)
         assert section_title.is_displayed(), 'Title Not Found'
 
     def check_visibility_concept_section(self):
+        self.open_road_risk_api_page()
         section_road_risk = self.driver.find_element(*R.SECTION_R_CONCEPTS)
         assert section_road_risk.is_displayed(), 'Section - NOT FOUND'
 
     def check_module_title_road_risk_page(self):
+        self.open_road_risk_api_page()
         expected_title = 'Road Risk API'
         title_module = self.driver.find_element(*R.TITLE_ROAD_RISK)
         assert expected_title in title_module.text, 'Title Not Found'
+
+    def check_redirection_to_the_section_of_the_page(self):
+        self.open_road_risk_api_page()
+        self.driver.find_element(*R.LINK_LIST_OF_NATIONAL).click()
+        assert self.element_is_visible(self.page_loc.TITLE_LIST_OF_NATIONAL).text == "List of national " \
+                                                                                     "weather warning sources"
 
 
 class WeatherConditionsPage(BasePage):

--- a/tests/test_group_100000/tests/test_road_risk_api_100.py
+++ b/tests/test_group_100000/tests/test_road_risk_api_100.py
@@ -1,20 +1,21 @@
 from tests.test_group_100000.pages.api_page import RoadRiskApi
-from tests.test_group_100000.locators.api_page_locators import RoadRiskApi as R
 
 
 def test_TC_005_08_04_redirection_to_the_how_to_request_road_risk_API_section_of_the_page(driver):
-    page = RoadRiskApi(driver, link=R.ROAD_RISK_API_LINK)
-    page.open_page()
+    page = RoadRiskApi(driver)
     page.check_redirect_to_page_section()
 
 
 def test_TC_005_08_03_road_risk_api_visibility_of_road_risk_api_concept_section(driver):
-    page = RoadRiskApi(driver, link=R.ROAD_RISK_API_LINK)
-    page.open_page()
+    page = RoadRiskApi(driver)
     page.check_visibility_concept_section()
 
 
 def test_TC_005_08_01_road_risk_api_verify_page_title_for_road_risk_api(driver):
-    page = RoadRiskApi(driver, link=R.ROAD_RISK_API_LINK)
-    page.open_page()
+    page = RoadRiskApi(driver)
     page.check_module_title_road_risk_page()
+
+
+def test_TC_005_08_05_redirection_to_the_list_of_sectional_sources_of_weather_warnings_section_of_the_page(driver):
+    page = RoadRiskApi(driver)
+    page.check_redirection_to_the_section_of_the_page()


### PR DESCRIPTION
AT_005.08.05 | Road Risk API >Redirection to the List of National Sources of Weather Warnings section of the page

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;MHvyOF0b&#x2F;1112-at0050805-road-risk-api-redirection-to-the-list-of-national-sources-of-weather-warnings-section-of-the-page">AT_005.08.05 | Road Risk API &gt;Redirection to the &quot;List of National Sources of Weather Warnings&quot; section of the page</a></blockquote>