### PR TITLE
RF|AT_001.15.07

### DIFF
--- a/tests/test_group_trust_me_i_am_engineer/pages/about_us_page.py
+++ b/tests/test_group_trust_me_i_am_engineer/pages/about_us_page.py
@@ -1,5 +1,3 @@
-from selenium.webdriver import ActionChains
-
 from pages.base_page import BasePage
 from tests.test_group_trust_me_i_am_engineer.locators.page_locators import AboutUsPageLocators
 
@@ -10,31 +8,27 @@ class AboutUsPage(BasePage):
     def open(self):
         self.driver.get(self.URL)
 
-    def verify_correct_header_about_us_page(self, wait):
+    def verify_correct_header_about_us_page(self):
         self.element_is_visible(self.page_locators.HEADER)
 
         assert self.element_is_visible(self.page_locators.HEADER).text == "OpenWeather\nglobal services"
 
-    def verify_image_beside_header_is_displayed(self, wait):
+    def verify_image_beside_header_is_displayed(self):
         image_beside_header = self.element_is_visible(self.page_locators.IMAGE_BESIDE_HEADER)
+
         assert image_beside_header.is_displayed(), "The image is not displayed beside the page header"
 
-    def verify_five_headers_on_the_page_about_us_footer(self, wait):
+    def verify_five_headers_on_the_page_about_us_footer(self):
         list_headers_on_page_footer = [el.text for el in self.elements_are_visible(self.page_locators.HEADERS_ON_PAGE_FOOTER)]
+
         assert list_headers_on_page_footer == ['Product Collections', 'Subscription', 'Company', 'Technologies', 'Terms & Conditions']
 
     def click_news_and_updates_button(self):
         self.element_is_clickable(self.page_locators.NEWS_AND_UPDATES_BUTTON).click()
 
-    def verify_current_url(self, button, expected_link):
-        self.driver.switch_to.window(self.driver.window_handles[1])
-        button_url = self.driver.current_url
-        assert button_url == expected_link, button + " button link is not correct"
-
     def check_cursor_style_transformation(self, element):
         element = element
-        actions = ActionChains(self.driver)
-        actions.move_to_element(element).perform()
+        self.action_move_to_element(element)
         cursor_style = element.value_of_css_property("cursor")
 
         assert cursor_style == "pointer", "Cursor is not transformed into a hand pointer."
@@ -45,7 +39,7 @@ class AboutUsPage(BasePage):
     def verify_element_on_current_url(self):
         self.driver.switch_to.window(self.driver.window_handles[1])
         expected_element = self.element_is_visible(self.page_locators.APP_TITLE)
-        print(expected_element.text)
+
         assert expected_element.text == "OpenWeather 4+"
 
 

--- a/tests/test_group_trust_me_i_am_engineer/pages/blog_category_weather_page.py
+++ b/tests/test_group_trust_me_i_am_engineer/pages/blog_category_weather_page.py
@@ -1,0 +1,11 @@
+from pages.base_page import BasePage
+
+
+class BlogCategoryWeatherPage(BasePage):
+
+    URL = "https://openweather.co.uk/blog/category/weather"
+
+    def verify_page_url(self, button, expected_link):
+        page_url = self.driver.current_url
+        assert page_url == expected_link, button + " button link is not correct"
+

--- a/tests/test_group_trust_me_i_am_engineer/tests/about_us_page_test_tmi.py
+++ b/tests/test_group_trust_me_i_am_engineer/tests/about_us_page_test_tmi.py
@@ -1,30 +1,34 @@
 from tests.test_group_trust_me_i_am_engineer.pages.about_us_page import AboutUsPage
+from tests.test_group_trust_me_i_am_engineer.pages.blog_category_weather_page import BlogCategoryWeatherPage
+
 
 def test_tc_001_15_01_verify_correct_header_about_us_page(driver, wait):
     about_us_page = AboutUsPage(driver)
     about_us_page.open()
 
-    about_us_page.verify_correct_header_about_us_page(wait)
+    about_us_page.verify_correct_header_about_us_page()
 
 def test_tc_001_15_02_verify_image_beside_header_is_displayed(driver, wait):
     about_us_page = AboutUsPage(driver)
     about_us_page.open()
 
-    about_us_page.verify_image_beside_header_is_displayed(wait)
+    about_us_page.verify_image_beside_header_is_displayed()
 
 def test_tc_001_15_05_there_are_five_headers_on_the_page_about_us_footer(driver, wait):
     about_us_page = AboutUsPage(driver)
     about_us_page.open()
 
-    about_us_page.verify_five_headers_on_the_page_about_us_footer(wait)
+    about_us_page.verify_five_headers_on_the_page_about_us_footer()
 
 def test_tc_001_15_07_verify_redirection_to_weather_category_blog_page(driver, wait):
     about_us_page = AboutUsPage(driver)
     about_us_page.open()
     about_us_page.allow_all_cookies()
     about_us_page.click_news_and_updates_button()
+    about_us_page.driver.switch_to.window(about_us_page.driver.window_handles[1])
 
-    about_us_page.verify_current_url("News and Updates", "https://openweather.co.uk/blog/category/weather")
+    blog_category_weather_page = BlogCategoryWeatherPage(driver)
+    blog_category_weather_page.verify_page_url("News and Updates", blog_category_weather_page.URL)
 
 def test_tc_001_15_10_verify_redirection_to_app_store(driver, wait):
     about_us_page = AboutUsPage(driver)
@@ -40,5 +44,6 @@ def test_tc_001_15_11_verify_cursor_transformation_after_hovering_over_on_elemen
     element = about_us_page.element_is_visible(about_us_page.page_locators.BYU_BY_SUBSCRIPTIONS)
 
     about_us_page.check_cursor_style_transformation(element)
+
 
 


### PR DESCRIPTION
https://trello.com/c/74Cj388k
create a new page class ‘blog_category_weather_page’ and move the method from about_page_class to the new class

RF|AT_001.15.07 | Main page > OpenWeather global services (About us)>verify that pushing the button "News and Updates" redirects to the page "Blog", category "Weather"