### PR TITLE
AT_017.03.11 | API Keys tab> Rename API key> Visibility, clickability, rename API keys>Verify the API key name is not generated if the input consists of spaces

### DIFF
--- a/tests/test_group_ducktales/pages/API_keys_page.py
+++ b/tests/test_group_ducktales/pages/API_keys_page.py
@@ -4,6 +4,7 @@ from tests.test_group_ducktales.pages.sign_in_page import SignInPage
 from ..test_data.sign_in_page_data import LINK_SIGN_IN_PAGE
 
 
+
 class ApiKeysPage(BasePage):
 
     def open_api_keys_page(self):
@@ -72,3 +73,14 @@ class ApiKeysPage(BasePage):
     def check_is_api_key_generated(self, initial_table_length):
         actual_api_keys_table_length = self.get_length_of_table_api_keys()
         assert actual_api_keys_table_length == initial_table_length + 1, "The new API key does not generated"
+
+
+
+    def check_api_key_is_not_generated(self, new_api_name):
+        initial_api_keys_table_length = self.get_length_of_table_api_keys()
+        self.enter_created_api_key_name(new_api_name)
+        self.click_generate_api_key_name_button()
+        final_api_keys_table_length = self.get_length_of_table_api_keys()
+        assert initial_api_keys_table_length == final_api_keys_table_length
+
+

--- a/tests/test_group_ducktales/test_data/api_keys_page_data.py
+++ b/tests/test_group_ducktales/test_data/api_keys_page_data.py
@@ -1,1 +1,2 @@
 LINK_API_KEYS_PAGE = "https://home.openweathermap.org/api_keys"
+SPACEKITS = [' ', '          ', '                    ']

--- a/tests/test_group_ducktales/tests/test_API_keys_page_d.py
+++ b/tests/test_group_ducktales/tests/test_API_keys_page_d.py
@@ -1,6 +1,8 @@
 from tests.test_group_ducktales.pages.sign_in_page import SignInPage
 from tests.test_group_ducktales.test_data.sign_in_page_data import *
 from tests.test_group_ducktales.pages.API_keys_page import ApiKeysPage
+from ..test_data.api_keys_page_data import SPACEKITS
+import pytest
 
 
 class TestApiKey:
@@ -33,4 +35,9 @@ class TestApiKey:
         api_keys_page.click_generate_api_key_name_button()
         api_keys_page.check_is_api_key_generated(initial_api_keys_table_length)
 
+    @pytest.mark.parametrize('spacekit', SPACEKITS)
+    def test_tc_017_03_11_api_key_is_not_generated_if_the_input_consists_of_spaces(self, driver, spacekit):
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.check_api_key_is_not_generated(spacekit)
 


### PR DESCRIPTION

TC https://trello.com/c/JkOltd3x/1565-tc0170311-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysverify-the-api-key-name-does-not-change-if-the-inpu

REF AT https://trello.com/c/vQpudd29/2129-rf-at0170311-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keys-verify-the-api-key-name-is-not-generated-if-the

OLD AT https://trello.com/c/D5GiAw1l/1503-at0170311-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysverify-the-api-key-name-is-not-generated-if-the-inp