### PR TITLE
RF_AT_003.11.02 | Footer > Copyright >Visibility, Content> Verify the copyright information is present on the site page

### DIFF
--- a/tests/test_group_100000/pages/api_page.py
+++ b/tests/test_group_100000/pages/api_page.py
@@ -3,6 +3,7 @@ from pages.base_page import BasePage
 from tests.test_group_100000.locators.api_page_locators import RoadRiskApi as R
 from tests.test_group_100000.locators.api_page_locators import WeatherConditions as W
 from tests.test_group_100000.locators.api_page_locators import OneCallApi as O
+from tests.test_group_100000.locators.main_page_locators import FooterBlockLocators as F
 
 
 class RoadRiskApi(BasePage):
@@ -68,5 +69,10 @@ class OneCallApiPage(BasePage):
         assert self.driver.current_url == expected_link, "This link is not correct"
 
 
-
-
+class FooterApiPage(BasePage):
+    def verify_the_copyright_information_is_present_on_the_site_page(self):
+        self.allow_all_cookies()
+        expected_footer_text = "© 2012 — 2023 OpenWeather"
+        footer = self.driver.find_element(*F.FOOTER_COPYRIGHT)
+        assert footer.is_displayed() and expected_footer_text in footer.text, \
+            "The footer is not displayed or does not contain the expected text"

--- a/tests/test_group_100000/tests/test_api_page_100.py
+++ b/tests/test_group_100000/tests/test_api_page_100.py
@@ -16,3 +16,10 @@ class TestOneCallApi:
         page = OneCallApiPage(driver, link=O.API_PAGE)
         page.open_page()
         page.verify_redirection_one_call_api_3_link()
+
+
+class TestCopyrightBlock:
+    def test_TC_003_11_02_verify_the_copyright_information_is_present_on_the_site_page(self, driver):
+        page = FooterApiPage(driver, link=O.API_PAGE)
+        page.open_page()
+        page.verify_the_copyright_information_is_present_on_the_site_page()


### PR DESCRIPTION
RF_AT_003.11.02 | Footer > Copyright >Visibility, Content> Verify the copyright information is present on the site page(API PAGE)

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;UJbuUw3X&#x2F;2097-rfat0031102-footer-copyright-visibility-content-verify-the-copyright-information-is-present-on-the-site-page">RF_AT_003.11.02 | Footer &gt; Copyright &gt;Visibility, Content&gt; Verify the copyright information is present on the site page</a></blockquote>