### PR TITLE
AT_003.02.08 Footer > Uniform display format > Verify display of Download OpenWeather app section on each page specified in Data

### DIFF
--- a/locators/locators.py
+++ b/locators/locators.py
@@ -32,6 +32,7 @@ class MainPageLocators:
     CONNECT_YOUR_WEATHER_STATION_LINK = (By.CSS_SELECTOR, "li a[href*='station']")
     COOKIES = (By.XPATH, "//button[contains(text(), 'Allow all')]")
     CURRENT_AND_FORECAST_APIS_LINK = (By.CSS_SELECTOR, '#footer-website a[href="/api#current"]')
+    DOWNLOAD_OPENWEATHER_APP_SECTION = (By.CSS_SELECTOR, '#footer-website > div > div:nth-child(3)')
     FOOTER_COMMON_KIT = (By.CSS_SELECTOR, "#footer-website")
     HISTORICAL_WEATHER_DATA_LINK = (By.CSS_SELECTOR,
                                     '#footer-website div :nth-child(1) :nth-child(1) ul :nth-child(2) > a')

--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -77,6 +77,10 @@ class MainPage(BasePage):
         single_links_section = self.element_is_visible(self.locators.SINGLE_LINKS_SECTION)
         assert single_links_section, "The single links section is not visible"
 
+    def check_download_openweather_app_section_is_visible(self):
+        download_openweather_app_section = self.element_is_visible(self.locators.DOWNLOAD_OPENWEATHER_APP_SECTION)
+        assert download_openweather_app_section, "The Download OpenWeather app section is not visible"
+
     def check_historical_weather_data_link_is_visible(self):
         historical_weather_data_link = self.element_is_visible(self.locators.HISTORICAL_WEATHER_DATA_LINK)
         assert historical_weather_data_link, "The Historical Weather Data link is not visible"

--- a/tests/test_main_page_ow6.py
+++ b/tests/test_main_page_ow6.py
@@ -60,6 +60,12 @@ class TestMainPage:
         page = MainPage(driver, link=URL)
         page.check_single_links_section_is_visible()
 
+    @pytest.mark.parametrize('URL', URLs)
+    def test_tc_003_02_08_verify_display_of_download_openweather_app_section_on_pages\
+                    (self, driver, open_and_load_main_page, URL):
+        page = MainPage(driver, link=URL)
+        page.check_download_openweather_app_section_is_visible()
+
     def test_tc_003_03_03_historical_weather_data_link_visibility(self, driver, open_and_load_main_page):
         page = MainPage(driver)
         page.check_historical_weather_data_link_is_visible()


### PR DESCRIPTION
https://trello.com/c/tkXifYOP/2225-at0030208-footer-uniform-display-format-verify-display-of-download-openweather-app-section-on-each-page-specified-in-data